### PR TITLE
Call cpp engine from rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         outputs: type=cacheonly
-        target: release
+        build-args: |
+          BUILD_TYPE:debug
+        target: build
 
     # TODO: Add step for running unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,19 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  ci:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      uses: docker/build-push-action@v6
+      with:
+        outputs: type=cacheonly
+        target: release
+
+    # TODO: Add step for running unit tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ name = "cmd"
 version = "0.1.0"
 dependencies = [
  "ffmpeg",
+ "libc",
  "upscaler",
  "util",
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apt install -y build-essential cmake
 # Depnedencies for ffmpeg
 RUN apt install -y libavformat-dev libavcodec-dev libavutil-dev
 
-## Image for building
-FROM base AS build
+## Release stage
+FROM base AS release
 WORKDIR /usr/src/viduce
 
 # Build cpp engine
@@ -17,13 +17,15 @@ RUN cmake -B build && cmake --build build
 COPY build/lib/libengine_api.so /lib/
 ENV LD_LIBRARY_PATH /lib
 
+# Build Rust
 # TODO: Leverage Docker caching for Rust dependencies
+# TODO: Look into having a separate env for building and running to reduce Docker img size
 WORKDIR /usr/src/viduce
 COPY . .
 RUN cargo build --release
 COPY target/release/cmd /bin/viduce
 
+## Execution stage
+FROM release AS run
 CMD ["viduce", "engine"]
-
-# TODO: Look into having a separate env for building and running to reduce Docker img size
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-## Base image for development and build. Should only contain env setup
+# Allow build type specification
+ARG BUILD_TYPE="debug"
+
+### Base image for development and build. Should only contain env setup
 FROM rust:1.92-bookworm AS base 
 RUN apt update
 
@@ -7,25 +10,37 @@ RUN apt install -y build-essential cmake
 # Depnedencies for ffmpeg
 RUN apt install -y libavformat-dev libavcodec-dev libavutil-dev
 
-## Release stage
-FROM base AS release
+### Temporary stages for build type
+FROM base AS build-debug
+ENV ENGINE_BUILD="Debug"
+ENV SERVICE_BUILD=""
+ENV SERVICE_PATH="debug"
+
+FROM base AS build-release
+ENV ENGINE_BUILD="Release"
+ENV SERVICE_BUILD="--release"
+ENV SERVICE_PATH="release"
+
+### Build stage
+FROM build-$BUILD_TYPE AS build
 WORKDIR /usr/src/viduce
+COPY . .
 
 # Build cpp engine
 WORKDIR engine
-RUN cmake -B build && cmake --build build
-COPY build/lib/libengine_api.so /lib/
-ENV LD_LIBRARY_PATH /lib
+RUN cmake -B build -DCMAKE_BUILD_TYPE=${ENGINE_BUILD}
+RUN cmake --build build -j 18
+RUN cp build/lib/libengine_api.so /lib/
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/lib"
 
 # Build Rust
 # TODO: Leverage Docker caching for Rust dependencies
-# TODO: Look into having a separate env for building and running to reduce Docker img size
 WORKDIR /usr/src/viduce
-COPY . .
-RUN cargo build --release
-COPY target/release/cmd /bin/viduce
+RUN cargo build ${SERVICE_BUILD}
+RUN cp target/${SERVICE_PATH}/cmd /bin/viduce
 
-## Execution stage
-FROM release AS run
+### Execution stage
+# TODO: Look into having a separate env for building and running to reduce Docker img size
+FROM build AS run
 CMD ["viduce", "engine"]
 

--- a/README.md
+++ b/README.md
@@ -27,4 +27,3 @@
 1. Come up with a heuristics to store just enough frames to be used with the description to be able to "restore" the video
 1. Use GenAI to "restore" the video using the downscaled frames + description
 
-

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -2,8 +2,10 @@
 name = "cmd"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 [dependencies]
 ffmpeg = { path = "../ffmpeg" }
 upscaler = { path = "../upscaler" }
 util = { path = "../util" }
+libc = "0.2.0"

--- a/cmd/build.rs
+++ b/cmd/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rustc-link-search=engine/build/lib");
+    println!("cargo:rustc-link-search=/lib");
+}

--- a/cmd/src/engine.rs
+++ b/cmd/src/engine.rs
@@ -1,0 +1,21 @@
+use libc::{c_char, c_int};
+
+// IMPORTANT: Make sure to set the LD_LIBRARY_PATH correctly to locate the
+// dynamic lib.
+#[link(name = "engine_api")]
+unsafe extern "C" {
+    fn DecodeVideo(input_path: *const c_char) -> c_int;
+}
+
+pub struct EngineRunner{}
+
+impl EngineRunner {
+    pub fn new() -> Self {
+        EngineRunner {}
+    }
+
+    pub fn run(&mut self) {
+        let res = unsafe { DecodeVideo(std::ffi::CString::new("assets/input/input.mp4").unwrap().as_ptr()) };
+        println!("DecodeVideo returned: {}", res);
+    }
+}

--- a/cmd/src/lib.rs
+++ b/cmd/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod ffmpeg;
 pub mod realesrgan;
 pub mod upscaler;
+pub mod engine;

--- a/cmd/src/main.rs
+++ b/cmd/src/main.rs
@@ -1,3 +1,4 @@
+use cmd::engine::EngineRunner;
 use cmd::ffmpeg::FfmpegRunner;
 use cmd::realesrgan::RealEsrganRunner;
 use cmd::upscaler::UpscalerRunner;
@@ -15,6 +16,7 @@ fn main() {
         "ffmpeg" => FfmpegRunner::new().run(),
         "upscaler" => UpscalerRunner::new().run(),
         "realesrgan" => RealEsrganRunner::new().run(),
+        "engine" => EngineRunner::new().run(),
         _ => println!("Unknown option {option}"),
     }
 }

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -4,10 +4,15 @@ project(viduce_engine)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+option(BUILD_TESTING "" OFF)
+if (CMAKE_BUILD_TYPE MATCHES "Debug")
+    set(BUILD_TESTING ON)
+    enable_testing()
+endif()
+
 add_subdirectory(deps)
 
 add_subdirectory(src)
 if (BUILD_TESTING)
-    enable_testing()
     add_subdirectory(test)
 endif()

--- a/engine/deps/CMakeLists.txt
+++ b/engine/deps/CMakeLists.txt
@@ -8,14 +8,16 @@ FetchContent_Declare(spdlog
 )
 add_subdirectory(spdlog)
 
-FetchContent_Declare(googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG v1.17.0
-)
-FetchContent_MakeAvailable(googletest)
-
 FetchContent_Declare(abseil
     GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
     GIT_TAG 20260107.0
 )
 FetchContent_MakeAvailable(abseil)
+
+if (BUILD_TESTING)
+    FetchContent_Declare(googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.17.0
+    )
+    FetchContent_MakeAvailable(googletest)
+endif()

--- a/engine/src/CMakeLists.txt
+++ b/engine/src/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_library(engine_api SHARED engine_api.cc)
 target_include_directories(engine_api PUBLIC ../include)
 target_link_libraries(engine_api PRIVATE spdlog::spdlog absl::status absl::strings avcodec avformat avutil)
+
+set_target_properties(engine_api PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+)

--- a/start_devenv.sh
+++ b/start_devenv.sh
@@ -8,4 +8,3 @@ podman run --name devenv -v "$(pwd)":/mnt/host/viduce -itd --rm devenv bash
 
 # Attach to the running container
 podman exec -it devenv bash
-

--- a/start_devenv.sh
+++ b/start_devenv.sh
@@ -8,3 +8,4 @@ podman run --name devenv -v "$(pwd)":/mnt/host/viduce -itd --rm devenv bash
 
 # Attach to the running container
 podman exec -it devenv bash
+


### PR DESCRIPTION
- Remove musl for statically compiling rust
    - For now, we will revert rust musl for static linking.

- Call cpp engine from Rust.
    - Also update the CI pipeline to successfully build the app