### PR TITLE
Create a dedicated deploy env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,8 @@ COPY . .
 # Build cpp engine
 WORKDIR engine
 RUN cmake -B build -DCMAKE_BUILD_TYPE=${ENGINE_BUILD}
-RUN cmake --build build -j 18
+RUN cmake --build build -j8
 RUN cp build/lib/libengine_api.so /lib/
-ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/lib"
 
 # Build Rust
 # TODO: Leverage Docker caching for Rust dependencies
@@ -49,4 +48,4 @@ RUN apt install -y ffmpeg
 COPY --from=build /bin/viduce /bin/viduce
 COPY --from=build /lib/libengine_api.so /lib/
 
-CMD ["viduce", "engine"]
+ENTRYPOINT ["/bin/viduce"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,13 @@ RUN cargo build ${SERVICE_BUILD}
 RUN cp target/${SERVICE_PATH}/cmd /bin/viduce
 
 ### Execution stage
-# TODO: Look into having a separate env for building and running to reduce Docker img size
-FROM build AS run
-CMD ["viduce", "engine"]
+## Image for deployment
+FROM debian:bookworm-slim
 
+RUN apt update
+RUN apt install -y ffmpeg
+
+COPY --from=build /bin/viduce /bin/viduce
+COPY --from=build /lib/libengine_api.so /lib/
+
+CMD ["viduce", "engine"]

--- a/cmd/build.rs
+++ b/cmd/build.rs
@@ -1,4 +1,3 @@
 fn main() {
     println!("cargo:rustc-link-search=engine/build/lib");
-    println!("cargo:rustc-link-search=/lib");
 }

--- a/engine/deps/CMakeLists.txt
+++ b/engine/deps/CMakeLists.txt
@@ -2,11 +2,7 @@
 
 include(FetchContent)
 
-FetchContent_Declare(spdlog
-    GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG v1.17.0
-)
-add_subdirectory(spdlog)
+include(spdlog.cmake)
 
 FetchContent_Declare(abseil
     GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git

--- a/engine/deps/ffmpeg.cmake
+++ b/engine/deps/ffmpeg.cmake
@@ -1,0 +1,69 @@
+include(ExternalProject)
+
+# Add more flags / options based on previous cmake flags
+ExternalProject_Add(ffmpeg
+    GIT_REPOSITORY https://git.ffmpeg.org/ffmpeg.git
+    GIT_TAG n8.0.1
+    CONFIGURE_COMMAND "./configure" "--disable-programs" "--disable-doc" "--enable-pic" "--enable-shared"
+    BUILD_IN_SOURCE ON
+    BUILD_COMMAND "make" "-j8"
+    INSTALL_COMMAND ""
+)
+ExternalProject_Get_Property(ffmpeg SOURCE_DIR)
+
+add_library(libavcodec SHARED IMPORTED GLOBAL)
+set_property(TARGET libavcodec
+    PROPERTY IMPORTED_LOCATION 
+    "${SOURCE_DIR}/libavcodec/libavcodec.so"
+)
+target_include_directories(libavcodec INTERFACE ${SOURCE_DIR})
+target_link_libraries(libavcodec INTERFACE libswresample)
+add_dependencies(libavcodec ffmpeg)
+
+add_library(libavdevice SHARED IMPORTED GLOBAL)
+set_property(TARGET libavdevice
+    PROPERTY IMPORTED_LOCATION 
+    "${SOURCE_DIR}/libavdevice/libavdevice.so"
+)
+target_include_directories(libavdevice INTERFACE ${SOURCE_DIR})
+add_dependencies(libavdevice ffmpeg)
+
+add_library(libavfilter SHARED IMPORTED GLOBAL)
+set_property(TARGET libavfilter
+    PROPERTY IMPORTED_LOCATION 
+    "${SOURCE_DIR}/libavfilter/libavfilter.so"
+)
+target_include_directories(libavfilter INTERFACE ${SOURCE_DIR})
+add_dependencies(libavfilter ffmpeg)
+
+add_library(libavformat SHARED IMPORTED GLOBAL)
+set_property(TARGET libavformat
+    PROPERTY IMPORTED_LOCATION 
+    "${SOURCE_DIR}/libavformat/libavformat.so"
+)
+target_include_directories(libavformat INTERFACE ${SOURCE_DIR})
+add_dependencies(libavformat ffmpeg)
+
+add_library(libavutil SHARED IMPORTED GLOBAL)
+set_property(TARGET libavutil
+    PROPERTY IMPORTED_LOCATION 
+    "${SOURCE_DIR}/libavutil/libavutil.so"
+)
+target_include_directories(libavutil INTERFACE ${SOURCE_DIR})
+add_dependencies(libavutil ffmpeg)
+
+add_library(libswresample SHARED IMPORTED GLOBAL)
+set_property(TARGET libswresample
+    PROPERTY IMPORTED_LOCATION 
+    "${SOURCE_DIR}/libswresample/libswresample.so"
+)
+target_include_directories(libswresample INTERFACE ${SOURCE_DIR})
+add_dependencies(libswresample ffmpeg)
+
+add_library(libswscale SHARED IMPORTED GLOBAL)
+set_property(TARGET libswscale
+    PROPERTY IMPORTED_LOCATION 
+    "${SOURCE_DIR}/libswscale/libswscale.so"
+)
+target_include_directories(libswscale INTERFACE ${SOURCE_DIR})
+add_dependencies(libswscale ffmpeg)

--- a/engine/deps/spdlog.cmake
+++ b/engine/deps/spdlog.cmake
@@ -1,0 +1,8 @@
+FetchContent_Declare(spdlog
+    GIT_REPOSITORY https://github.com/gabime/spdlog.git
+    GIT_TAG v1.17.0
+)
+
+set(SPDLOG_BUILD_PIC ON)
+
+FetchContent_MakeAvailable(spdlog)

--- a/engine/deps/spdlog/CMakeLists.txt
+++ b/engine/deps/spdlog/CMakeLists.txt
@@ -1,3 +1,0 @@
-set(SPDLOG_BUILD_PIC ON)
-
-FetchContent_MakeAvailable(spdlog)

--- a/engine/src/CMakeLists.txt
+++ b/engine/src/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_library(engine_api SHARED engine_api.cc)
 target_include_directories(engine_api PUBLIC ../include)
 target_link_libraries(engine_api PRIVATE spdlog::spdlog absl::status absl::strings avcodec avformat avutil)
-target_link_options(engine_api PRIVATE -static-libgcc -static-libstdc++)
 
 set_target_properties(engine_api PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"

--- a/engine/src/CMakeLists.txt
+++ b/engine/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(engine_api SHARED engine_api.cc)
 target_include_directories(engine_api PUBLIC ../include)
 target_link_libraries(engine_api PRIVATE spdlog::spdlog absl::status absl::strings avcodec avformat avutil)
+target_link_options(engine_api PRIVATE -static-libgcc -static-libstdc++)
 
 set_target_properties(engine_api PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"


### PR DESCRIPTION
Update engine_api to link to stdc++ statically

Create a separate image for deployment

Refactor spdlog import into a separate cmake file.

WIP: Add explicit dependency specification. For now, let's just prefer system wide dependency.